### PR TITLE
Out with the old, in with the new.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,27 +2,11 @@
 /* eslint-disable object-shorthand */
 'use strict';
 
-const fastbootTransform = require('fastboot-transform');
 const mergeTrees = require('broccoli-merge-trees');
 const writeFile = require('broccoli-file-creator');
 
 module.exports = {
   name: 'ember-cli-rollbar',
-  options: {
-    nodeAssets: {
-      'rollbar': function() {
-        return {
-          vendor: {
-            srcDir: 'dist',
-            include: ['*.js'],
-            processTree(input) {
-              return fastbootTransform(input);
-            }
-          }
-        };
-      }
-    }
-  },
 
   _getConfig() {
     let env = this.app.env;
@@ -46,12 +30,17 @@ module.exports = {
     return this._super.treeForVendor.call(this, tree);
   },
 
-  included: function(app) {
+  included(app) {
     this._super.included.apply(this, arguments);
 
-    // Always include, but it may be disabled based on the configuration.
-    app.import('vendor/rollbar/rollbar.snippet.js', { prepend: true });
-    app.import('vendor/ember-cli-rollbar/config.js', { prepend: true });
+    app.import('node_modules/rollbar/dist/rollbar.snippet.js', {
+      prepend: true,
+      using: [{transformation: 'fastbootShim'}]
+    });
+    app.import('vendor/ember-cli-rollbar/config.js', {
+      prepend: true,
+      using: [{transformation: 'fastbootShim'}]
+    });
     app.import('vendor/rollbar-module.js');
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,6 +1733,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.5.0.tgz",
       "integrity": "sha1-16+MGFEdzlEOSdMIpi5Zd/RhiDw=",
+      "dev": true,
       "requires": {
         "broccoli-debug": "0.6.3",
         "broccoli-funnel": "1.2.0",
@@ -1754,6 +1755,7 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
+          "dev": true,
           "requires": {
             "broccoli-plugin": "1.3.0",
             "can-symlink": "1.0.0",
@@ -3091,6 +3093,101 @@
         }
       }
     },
+    "ember-cli-fastboot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-fastboot/-/ember-cli-fastboot-1.1.1.tgz",
+      "integrity": "sha512-hctBX1MQYTDjYF2ISR6qZIT+fY4mmJFwCskNM/ruHTmN0XKgSSvRijRfF9y/VgpDux77iEDMNT9C5ZIzhSFEoA==",
+      "dev": true,
+      "requires": {
+        "broccoli-concat": "3.2.2",
+        "broccoli-funnel": "2.0.1",
+        "broccoli-merge-trees": "2.0.0",
+        "broccoli-plugin": "1.3.0",
+        "chalk": "2.3.0",
+        "ember-cli-babel": "6.8.2",
+        "ember-cli-lodash-subset": "2.0.1",
+        "ember-cli-version-checker": "2.0.0",
+        "fastboot": "1.1.2",
+        "fastboot-express-middleware": "1.1.1",
+        "fastboot-transform": "0.1.2",
+        "fs-extra": "4.0.3",
+        "json-stable-stringify": "1.0.1",
+        "md5-hex": "2.0.0",
+        "silent-error": "1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.9",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.2",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "ember-cli-get-component-path-option": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz",
@@ -3205,36 +3302,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz",
       "integrity": "sha1-IMtop5D+D94kiN39jvu332/nZvI=",
       "dev": true
-    },
-    "ember-cli-node-assets": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz",
-      "integrity": "sha1-0tVWJufMZhn4gtf+VXUfkmYCJwg=",
-      "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-source": "1.1.0",
-        "debug": "2.6.9",
-        "lodash": "4.17.4",
-        "resolve": "1.4.0"
-      },
-      "dependencies": {
-        "broccoli-merge-trees": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
-          }
-        }
-      }
     },
     "ember-cli-normalize-entity-name": {
       "version": "1.0.0",
@@ -4389,10 +4456,130 @@
         }
       }
     },
+    "fastboot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastboot/-/fastboot-1.1.2.tgz",
+      "integrity": "sha512-d04JsNuKCFmCZi7TuFKK6CR/XH/JInobMizAFPA4IRu2jUXcSBG63ZyqH7vWQa+BS27O2yDNXXzySgCz4iYMyA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "cookie": "0.3.1",
+        "debug": "3.1.0",
+        "exists-sync": "0.0.4",
+        "najax": "1.0.3",
+        "rsvp": "4.7.0",
+        "simple-dom": "1.3.0",
+        "source-map-support": "0.5.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "rsvp": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.7.0.tgz",
+          "integrity": "sha1-3BsLGlNvfeydK+ReChKtQZfJ/ZY=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+          "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "fastboot-express-middleware": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fastboot-express-middleware/-/fastboot-express-middleware-1.1.1.tgz",
+      "integrity": "sha512-XAB7oVThwvN/v5uI8jWkdwpm/4mAREgTkEFfWyAIPWTw3/adrQQTGBESEo0gei3N3dwdYFafdKKjWBPW6WhkPA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "fastboot": "1.1.2",
+        "request": "2.83.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "fastboot-transform": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/fastboot-transform/-/fastboot-transform-0.1.2.tgz",
-      "integrity": "sha1-+RDWZquT51YESS6mVScNGAS8jec=",
+      "integrity": "sha512-SU343Ca3XeiGHxSvycVb3062ejN68Go8OXcx4QWgUUMek43XRUr/LuU4ILSxAMvvHvhamsSQivysWBEO9ux4oA==",
+      "dev": true,
       "requires": {
         "broccoli-stew": "1.5.0"
       }
@@ -4598,6 +4785,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
       "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "2.4.0"
@@ -5715,7 +5903,8 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -6312,6 +6501,12 @@
       "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=",
       "dev": true
     },
+    "jquery-deferred": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/jquery-deferred/-/jquery-deferred-0.3.1.tgz",
+      "integrity": "sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=",
+      "dev": true
+    },
     "js-reporters": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.0.tgz",
@@ -6435,6 +6630,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -7368,6 +7564,17 @@
         "any-promise": "1.3.0",
         "object-assign": "4.1.1",
         "thenify-all": "1.6.0"
+      }
+    },
+    "najax": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/najax/-/najax-1.0.3.tgz",
+      "integrity": "sha1-ERRfTZEERupmHYq3/O9T9q0WSuU=",
+      "dev": true,
+      "requires": {
+        "jquery-deferred": "0.3.1",
+        "lodash.defaultsdeep": "4.6.0",
+        "qs": "6.5.1"
       }
     },
     "nan": {
@@ -8520,6 +8727,12 @@
       "requires": {
         "debug": "2.6.9"
       }
+    },
+    "simple-dom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/simple-dom/-/simple-dom-1.3.0.tgz",
+      "integrity": "sha512-RVjr6e80FFGDqDJZeQd4EMwoDLatn4Jy2SfuXecrP1IgG4ZAqkGSokE8LNV5i0kzWR2IM0e257xGN9JS8lxm0Q==",
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
   "dependencies": {
     "broccoli-file-creator": "^1.1.1",
     "broccoli-merge-trees": "^2.0.0",
-    "ember-cli-babel": "^6.6.0",
-    "ember-cli-node-assets": "^0.2.2",
-    "fastboot-transform": "^0.1.2"
+    "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -34,6 +32,7 @@
     "ember-cli": "~2.17.1",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
+    "ember-cli-fastboot": "^1.1.1",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",


### PR DESCRIPTION
1. Now that ember-cli can import directly from node_modules, we don't need ember-cli-node-assets.
2. Also, ember-cli-fastboot provides the same fastboot shim integrated directly into app.import.