### PR TITLE
Add rollbar service

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,33 @@ If `enabled` is not set, this addon will automatically enable Rollbar if the Emb
   If you prefer to not have your errors logged to the console, set this to `false`.
 - `captureEmberLogger`: Defaults to `false`. The addon can override `Ember.Logger` and send those notifications to Rollbar.
 
+## Rollbar service
+
+This adds a `rollbar` service to your app which exposes the Rollbar client library to your application. 
+You can use this service to log messages explicitly in outside of exceptions or `Ember.Logger` overrides:
+
+```js
+  import Controller from '@ember/controller';
+  import { inject as service } from '@ember/service';
+  
+  export default Controller.extend({
+    rollbar: service(),
+  
+    actions: {
+      doSomething() {
+        try {
+          somethingThatMightFail();
+        } catch (err) {
+          this.get('rollbar').error('Caught an exception', err);
+        }
+      }
+    }
+  });
+```
+
+The service directly exposes the methods `log`, `debug`, `info`, `warn`, `warning`, `error`, and `critical`.
+The Rollbar client instance itself can be accessed via the `instance` property.
+
 ## FastBoot Support
 
 FastBoot support is *mostly* automatic, however there some changes you will need to make to your project: 

--- a/addon/initializers/rollbar.js
+++ b/addon/initializers/rollbar.js
@@ -4,6 +4,7 @@ export function initialize(application) {
   let config = new RollbarConfig(application.resolveRegistration('config:environment'));
   if (config.rollbarConfig.enabled) {
     let instance = config.newInstance();
+    application.register('rollbar:main', instance, { instantiate: false });
     if (config.addonConfig.captureEmberErrors) {
       captureEmberErrors(instance, config.addonConfig.outputEmberErrorsToConsole);
     }

--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -1,0 +1,51 @@
+import Service from '@ember/service';
+import { getOwner } from '@ember/application';
+
+function wrapConsole(name) {
+  /* eslint-disable no-console */
+  return (console && console[name]) ? console[name] : console.error;
+}
+
+export default Service.extend({
+  init() {
+    this._super(...arguments);
+
+    let rollbar = getOwner(this).lookup('rollbar:main');
+    if (rollbar) {
+      this.instance = rollbar;
+    } else {
+      // In this case, forward to the console if it exists
+      this.instance = {
+        log: wrapConsole('log'),
+        debug: wrapConsole('debug'),
+        info: wrapConsole('info'),
+        warn: wrapConsole('warn'),
+        warning: wrapConsole('warn'),
+        error: wrapConsole('error'),
+        critical: wrapConsole('error'),
+      };
+    }
+  },
+
+  log() {
+    return this.instance.log(...arguments);
+  },
+  debug() {
+    return this.instance.debug(...arguments);
+  },
+  info() {
+    return this.instance.info(...arguments);
+  },
+  warn() {
+    return this.instance.warn(...arguments);
+  },
+  warning() {
+    return this.instance.warning(...arguments);
+  },
+  error() {
+    return this.instance.error(...arguments);
+  },
+  critical() {
+    return this.instance.critical(...arguments);
+  }
+});

--- a/app/services/rollbar.js
+++ b/app/services/rollbar.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-rollbar2/services/rollbar';

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,0 +1,30 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+  rollbar: service(),
+
+  actions: {
+    log() {
+      this.get('rollbar').log('Test log');
+    },
+    debug() {
+      this.get('rollbar').debug('Test debug');
+    },
+    info() {
+      this.get('rollbar').info('Test info');
+    },
+    warn() {
+      this.get('rollbar').warn('Test warn');
+    },
+    warning() {
+      this.get('rollbar').warning('Test warning');
+    },
+    error() {
+      this.get('rollbar').error('Test error');
+    },
+    critical() {
+      this.get('rollbar').critical('Test critical');
+    }
+  }
+});

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,6 +9,7 @@
 
     {{content-for "head"}}
 
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,1 @@
-<h2 id="title">Welcome to Ember</h2>
-
 {{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,18 @@
+<div class="container">
+  <div class="row">
+    <div class="col">
+      <h1>Ember Rollbar Test</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <button class="btn btn-primary" onclick={{action 'log'}}>Log</button>
+      <button class="btn btn-secondary" onclick={{action 'debug'}}>Debug</button>
+      <button class="btn btn-info" onclick={{action 'info'}}>Info</button>
+      <button class="btn btn-warning" onclick={{action 'warn'}}>Warn</button>
+      <button class="btn btn-warning" onclick={{action 'warning'}}>Warning</button>
+      <button class="btn btn-danger" onclick={{action 'error'}}>Error</button>
+      <button class="btn btn-danger" onclick={{action 'critical'}}>Critical</button>
+    </div>
+  </div>
+</div>

--- a/tests/unit/initializers/rollbar-test.js
+++ b/tests/unit/initializers/rollbar-test.js
@@ -44,7 +44,6 @@ test('it works', function(assert) {
   initialize(this.application);
   // Ember.Logger methods are patched
   assert.ok(Logger.info.toString().includes('rollbarWrapper'));
-
-  // you would normally confirm the results of the initializer here
-  assert.ok(true);
+  // Ensure that the instance is registered
+  assert.ok(this.application.__container__.lookup('rollbar:main'));
 });

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:rollbar', 'Unit | Service | rollbar', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+test('it exists', function(assert) {
+  let service = this.subject();
+  // Ensure that all the function are wrapped?
+  assert.ok(service.instance);
+  service.log('log');
+  service.debug('debug');
+  service.info('info');
+  service.warn('warn');
+  service.warning('warning');
+  service.error('error');
+  service.critical('critical');
+});


### PR DESCRIPTION
Previously, there was no way to access the rollbar instance created in the initializer, in case we wanted to explicitly send things to rollbar. Now there is.