### PR TITLE
IE fix

### DIFF
--- a/addon/services/rollbar.js
+++ b/addon/services/rollbar.js
@@ -3,7 +3,11 @@ import { getOwner } from '@ember/application';
 
 function wrapConsole(name) {
   /* eslint-disable no-console */
-  return (console && console[name]) ? console[name] : console.error;
+  return function() {
+    if (console && console[name]) {
+      console[name](...arguments);
+    }
+  };
 }
 
 export default Service.extend({

--- a/tests/unit/services/rollbar-test.js
+++ b/tests/unit/services/rollbar-test.js
@@ -9,11 +9,15 @@ test('it exists', function(assert) {
   let service = this.subject();
   // Ensure that all the function are wrapped?
   assert.ok(service.instance);
-  service.log('log');
-  service.debug('debug');
-  service.info('info');
-  service.warn('warn');
-  service.warning('warning');
-  service.error('error');
-  service.critical('critical');
+  try {
+    service.log('log');
+    service.debug('debug');
+    service.info('info');
+    service.warn('warn');
+    service.warning('warning');
+    service.error('error');
+    service.critical('critical');
+  } catch (err) {
+    assert.notOk(err, 'These should not fail');
+  }
 });


### PR DESCRIPTION
console is dynamically available on IE, so we can't wrap it once.