### PR TITLE
Deprecate captureEmberLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ If `enabled` is not set, this addon will automatically enable Rollbar if the Emb
 - `captureEmberErrors`: Defaults to `true`. The addon can set `Ember.onerror` to capture errors sent by Ember.
 - `outputEmberErrorsToConsole`: Defaults to `true`. When catching Ember errors, it also writes these errors to the console.
   If you prefer to not have your errors logged to the console, set this to `false`.
-- `captureEmberLogger`: Defaults to `false`. The addon can override `Ember.Logger` and send those notifications to Rollbar.
 
 ## Rollbar service
 

--- a/addon/initializers/rollbar.js
+++ b/addon/initializers/rollbar.js
@@ -1,3 +1,4 @@
+import { deprecate } from '@ember/application/deprecations';
 import { RollbarConfig, captureEmberErrors, captureEmberLogger } from '../utils/rollbar';
 
 export function initialize(application) {
@@ -8,6 +9,12 @@ export function initialize(application) {
     if (config.addonConfig.captureEmberErrors) {
       captureEmberErrors(instance, config.addonConfig.outputEmberErrorsToConsole);
     }
+    deprecate(
+      'captureEmberLogger is deprecated (along with Ember.Logger) and will be removed in a future release.',
+      !config.addonConfig.captureEmberLogger, {
+        id: 'RB-LOGGER-1',
+        until: '1.0'
+      });
     if (config.addonConfig.captureEmberLogger) {
       captureEmberLogger(instance);
     }

--- a/addon/utils/rollbar.js
+++ b/addon/utils/rollbar.js
@@ -102,7 +102,8 @@ export function captureEmberErrors(instance, outputToConsole = true) {
   }
 
   if (outputToConsole) {
-    let origError = Logger.error;
+    /* eslint-disable no-console */
+    let origError = console.error;
     Ember.onerror = function(err) {
       instance.error(err);
       origError(getStack(err));

--- a/tests/unit/utils/rollbar-test.js
+++ b/tests/unit/utils/rollbar-test.js
@@ -108,7 +108,7 @@ module('Unit | Utility | rollbar', function(hooks) {
       let mock = this.sinon.mock(rollbar);
       mock.expects('error');
 
-      let log = this.sinon.spy(Logger, 'error');
+      let log = this.sinon.spy(console, 'error');
 
       let result = captureEmberErrors(rollbar);
       Ember.onerror(new Error('hello'));
@@ -123,7 +123,7 @@ module('Unit | Utility | rollbar', function(hooks) {
       let mock = this.sinon.mock(rollbar);
       mock.expects('error');
 
-      let log = this.sinon.spy(Logger, 'error');
+      let log = this.sinon.spy(console, 'error');
 
       captureEmberErrors(rollbar, false);
       Ember.onerror(new Error('hello'));


### PR DESCRIPTION
Ember.Logger is deprecated in Ember >= 3.2.